### PR TITLE
add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "5.0.0",
   "description": "johnny-five compatible lib for oled devices",
   "main": "oled.js",
+  "files": [
+    "oled.js"
+  ],
   "devDependencies": {
     "johnny-five": "*",
     "oled-font-5x7": "~1.0.0",


### PR DESCRIPTION
Adds the `files` field to the `package.json` which whitelists only the `oled.js` file for smaller package size.  #133 