### PR TITLE
Consistency in the color definition

### DIFF
--- a/oled.js
+++ b/oled.js
@@ -500,11 +500,11 @@ class Oled {
       (page === 0) ? byte = x : byte = x + (this.WIDTH * page)
 
       // colors! Well, monochrome.
-      if (color === 'BLACK' || color === 0) {
+      if (color === 0) {
+        // BLACK pixel
         this.buffer[byte] &= ~pageShift
-      }
-
-      if (color === 'WHITE' || color > 0) {
+      } else {
+        // WHITE pixel
         this.buffer[byte] |= pageShift
       }
 


### PR DESCRIPTION
Hello again!

The implicit definition of `color` in `drawPixel` was not following the documentation: the strings `BLACK` and `WHITE` were acceptable `color` values, but not documented.

I thought about just changing the documentation, however, it felt more natural to me to only use numbers.
Moreover, `writeString` was not correct when using `WHITE` as the `color` (because at line 296, `Number(!color)` would evaluate to `0`, which is the `BLACK` value).
The other solution would be to normalize all `color` parameters, which seemed overkill.

Good day!